### PR TITLE
Closes #45: Add code coverage reports with grunt-instanbul

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -40,6 +40,8 @@ module.exports = (grunt) ->
     "jasmine_node":
       run:
         spec: "lib/test/"
+      runCoverage:
+        spec: "lib/coverage/instrument/lib/test"
       env:
         NODE_PATH: "lib"
       executable: './node_modules/.bin/jasmine_node'
@@ -111,6 +113,30 @@ module.exports = (grunt) ->
         files:
           'build/dev/index.css': ['dev/index.sass']
 
+    instrument:
+      files: ["lib/*.js", "lib/validators/*.js"]
+      options:
+        lazy: true
+        basePath: "lib/coverage/instrument"
+
+    copy:
+      tests:
+        expand: true
+        flatten: true
+        src: "lib/test/*"
+        dest: "lib/coverage/instrument/lib/test/"
+
+    storeCoverage:
+      options:
+        dir: "lib/coverage/reports"
+
+    makeReport:
+      src: "lib/coverage/reports/**/*.json"
+      options:
+        type: "lcov"
+        dir: "lib/coverage/reports"
+        print: "detail"
+
   # Load the plugin that provides the "uglify" task.
   grunt.loadNpmTasks 'grunt-contrib-uglify'
   #grunt.loadNpmTasks 'grunt-contrib-jasmine'
@@ -125,9 +151,12 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-push-release'
   grunt.loadNpmTasks 'grunt-contrib-jade'
   grunt.loadNpmTasks 'grunt-contrib-sass'
+  grunt.loadNpmTasks('grunt-istanbul')
+  grunt.loadNpmTasks('grunt-contrib-copy')
 
   # Default task(s).
   grunt.registerTask 'default', ['coffeelint', 'coffee', 'browserify', 'concat', 'jasmine_node', 'jade', 'sass', 'uglify']
   grunt.registerTask 'travis', ['coffeelint', 'coffee', 'jasmine_node']
   grunt.registerTask 'test', ['coffee', 'jasmine_node']
+  grunt.registerTask 'coverage', ['coffee', 'instrument', 'copy:tests', 'jasmine_node:runCoverage', 'storeCoverage', 'makeReport']
   grunt.registerTask 'build', ['coffeelint', 'coffee', 'browserify', 'concat', 'jade', 'sass', 'uglify']

--- a/package.json
+++ b/package.json
@@ -32,21 +32,23 @@
     "estraverse": "~1.5.0"
   },
   "devDependencies": {
-    "grunt-contrib-uglify": "~0.2.2",
-    "grunt-contrib-jasmine": "~0.5.1",
-    "grunt-coffeelint": "~0.0.7",
     "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-watch": "~0.5.1",
     "grunt-browserify": "https://github.com/nwinter/grunt-browserify/tarball/master",
-    "jasmine-node": "~1.11.0",
+    "grunt-coffeelint": "~0.0.7",
+    "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-concat": "~0.3.0",
-    "grunt-notify": "~0.2.7",
-    "grunt-jasmine-node": "~0.1.0",
-    "grunt-gh-pages": "~0.9.0",
-    "grunt-push-release": "~0.1.1",
+    "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-jade": "~0.9.1",
-    "grunt-contrib-sass": "~0.7.2"
+    "grunt-contrib-jasmine": "~0.5.1",
+    "grunt-contrib-sass": "~0.7.2",
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-contrib-watch": "~0.5.1",
+    "grunt-gh-pages": "~0.9.0",
+    "grunt-istanbul": "^0.2.5",
+    "grunt-jasmine-node": "~0.1.0",
+    "grunt-notify": "~0.2.7",
+    "grunt-push-release": "~0.1.1",
+    "jasmine-node": "~1.11.0"
   },
   "scripts": {
     "test": "grunt travis --verbose"


### PR DESCRIPTION
If you run "grunt coverage", it will now display a basic summary in the command window and a detailed report of code coverage (you can drill right into the files) is produced at lib/coverage/reports/lcov-report/index.html.
