### PR TITLE
Fix coverage task to recursively instrument files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Thumbs.db
 nbproject
 
 .grunt
+coverage/

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -41,7 +41,7 @@ module.exports = (grunt) ->
       run:
         spec: "lib/test/"
       runCoverage:
-        spec: "lib/coverage/instrument/lib/test"
+        spec: "coverage/instrument/lib/test"
       env:
         NODE_PATH: "lib"
       executable: './node_modules/.bin/jasmine_node'
@@ -117,24 +117,24 @@ module.exports = (grunt) ->
       files: "lib/**/*.js"
       options:
         lazy: true
-        basePath: "lib/coverage/instrument"
+        basePath: "coverage/instrument"
 
     copy:
       tests:
         expand: true
         flatten: true
         src: "lib/test/**/*"
-        dest: "lib/coverage/instrument/lib/test/"
+        dest: "coverage/instrument/lib/test/"
 
     storeCoverage:
       options:
-        dir: "lib/coverage/reports"
+        dir: "coverage/reports"
 
     makeReport:
-      src: "lib/coverage/reports/**/*.json"
+      src: "coverage/reports/**/*.json"
       options:
         type: "lcov"
-        dir: "lib/coverage/reports"
+        dir: "coverage/reports"
         print: "detail"
 
   # Load the plugin that provides the "uglify" task.


### PR DESCRIPTION
Fix coverage task by recursively instrumenting all files under app (so now does new languages folder)

Tests is also instrumented but then overwritten by copy:tests task: this avoids generating code coverage data about these.
