### PR TITLE
Change protection API to decouple clones from values

### DIFF
--- a/src/aether.coffee
+++ b/src/aether.coffee
@@ -41,6 +41,10 @@ module.exports = class Aether
     @setLanguage @options.language, @options.languageVersion
     @allGlobals = @options.globals.concat protectBuiltins.builtinNames, Object.keys @language.runtimeGlobals  # After setLanguage, which can add globals.
 
+    ## For mapping API clones and values to each other
+    @protectAPIClonesToValues = {}
+    @protectAPIValuesToClones = {}
+
   # Language can be changed after construction. (It will reset Aether's state.)
   setLanguage: (language, languageVersion) ->
     return if @language and @language.id is language and @language.version is languageVersion

--- a/src/protectAPI.coffee
+++ b/src/protectAPI.coffee
@@ -18,11 +18,20 @@ cloneableClasses = {}
 cloneableClasses[funcClass] = false
 cloneableClasses[argsClass] = cloneableClasses[arrayClass] = cloneableClasses[boolClass] = cloneableClasses[dateClass] = cloneableClasses[numberClass] = cloneableClasses[objectClass] = cloneableClasses[regexpClass] = cloneableClasses[stringClass] = true
 
+# Increments for each object that is protected
+#   because this is known (and can be faked from the user end)
+#   we must only pass objects to the protection API that are
+#   otherwise available to the user.
+#
+#   CSPRNG would mean that we could map anything we wanted without
+#   any this problem -BUT- was avoided for performance reasons.
+protectionIdCounter = 0
+
 # Used to match regexp flags from their coerced string values.
 reFlags = /\w*$/
 
 # Hacky reimplementation of lodash's cloneDeep, minus the parts we don't need, plus limiting clones to apiProperties.
-module.exports.createAPIClone = createAPIClone = (value) ->
+module.exports.createAPIClone = createAPIClone = (aether, value) ->
   return value unless _.isObject value
   className = Object::toString.call value
   return value unless cloneableClasses[className]
@@ -37,9 +46,12 @@ module.exports.createAPIClone = createAPIClone = (value) ->
       result.lastIndex = value.lastIndex
       return result
 
-  # Check for circular references and return corresponding clone.
-  return clone if clone = value.__aetherAPIClone
-  return value if value.__aetherAPIValue
+  if value.__aetherID?
+    id = value.__aetherID
+    return result if (result = aether.protectAPIValuesToClones[id])?
+  else
+    id = protectionIdCounter++
+    Object.defineProperty value, '__aetherID', value: id
 
   if isArr = _.isArray value
     result = ctor value.length
@@ -49,14 +61,15 @@ module.exports.createAPIClone = createAPIClone = (value) ->
   else
     result = {}
 
-  # Add the source value to the stack of traversed objects and associate it with its clone.
-  # Object.defineProperty defaults to non-configurable, non-enumerable, non-writable.
-  Object.defineProperty value, "__aetherAPIClone", value: result, writable: true, configurable: true
-  Object.defineProperty result, "__aetherAPIValue", value: value
+  # Link the value and the clone together
+  Object.defineProperty result, '__aetherID', value: id
+
+  aether.protectAPIValuesToClones[id] = result
+  aether.protectAPIClonesToValues[id] = value
 
   # Recursively populate clone (susceptible to call stack limits) with non-configurable, non-writable properties.
   if isArr
-    result[i] = createAPIClone v for v, i in value
+    result[i] = createAPIClone aether, v for v, i in value
     #Object.freeze result  # Do we want to freeze arrays? Maybe not; caused bug with defining __aetherAPIClone.
   else if value.apiProperties
     for prop in value.apiMethods ? []
@@ -69,32 +82,34 @@ module.exports.createAPIClone = createAPIClone = (value) ->
     for prop in value.apiProperties when not result[prop]?  # Don't redefine it if it's already done.
       do (prop) ->
         # Accessing a property on the clone will get the value from the original.
-        fn = -> createAPIClone value[prop]
+        fn = ->
+          createAPIClone aether, value[prop]
+
         Object.defineProperty result, prop, get: fn, enumerable: true
     for prop in value.apiUserProperties ? [] when not result[prop]?  # Don't redefine it if it's already done.
-      result[prop] = createAPIClone value[prop]  # Maybe we don't need to clone this?
+      result[prop] = createAPIClone aether, value[prop]  # Maybe we don't need to clone this?
   else
     # Hmm, should we protect normal objects?
     #result[k] = createAPIClone(v) for own k, v of value
-    Object.defineProperty result, k, value: createAPIClone(v), enumerable: true for own k, v of value
+    Object.defineProperty result, k, value: createAPIClone(aether,v), enumerable: true for own k, v of value
 
   result
 
 # Hmm; this will make it so that if we are, say, passing an array or object around, even if it doesn't have an API,
 # then modifications to the contents will be ignored after clone restoration. Is this bad?
-module.exports.restoreAPIClone = restoreAPIClone = (value, depth=0) ->
+module.exports.restoreAPIClone = restoreAPIClone = (aether, value, depth=0) ->
   return value unless _.isObject value
   className = Object::toString.call value
   return value unless cloneableClasses[className]
   return value if className in [boolClass, dateClass, numberClass, stringClass, regexpClass]
-  return source if source = value.__aetherAPIValue
-  return source if source = value.__aetherAPIClone?.__aetherAPIValue  # hack, but this helped in one case, not sure why
+  return source if (source = aether.protectAPIClonesToValues[value.__aetherID])?
+  #return source if source = value.__aetherAPIClone?.__aetherAPIValue  # hack, but this helped in one case, not sure why
   return value if depth > 1  # hack, but I don't understand right now--when do we stop? can't recurse forever
 
   # We now have a new array/object that may contain some clones, so let's recurse to find them.
   if isArr = _.isArray value
-    result = (restoreAPIClone v, depth + 1 for v in value)
+    result = (restoreAPIClone aether, v, depth + 1 for v in value)
   else
     result = {}
-    result[k] = restoreAPIClone v, depth + 1 for k, v of value
+    result[k] = restoreAPIClone aether, v, depth + 1 for k, v of value
   result

--- a/src/transforms.coffee
+++ b/src/transforms.coffee
@@ -194,17 +194,17 @@ module.exports.protectAPI = (node) ->
   # Restore clones when passing to functions or returning them.
   if node.type is S.CallExpression
     for arg in node.arguments
-      arg.update "_aether.restoreAPIClone(#{arg.source()})"
+      arg.update "_aether.restoreAPIClone(_aether, #{arg.source()})"
   else if node.type is S.ReturnStatement and arg = node.argument
-    arg.update "_aether.restoreAPIClone(#{arg.source()})"
+    arg.update "_aether.restoreAPIClone(_aether, #{arg.source()})"
 
   # Create clones from arguments and function return values.
   if node.parent.type is S.AssignmentExpression or node.type is S.ThisExpression
-    node.update "_aether.createAPIClone(#{node.source()})"
+    node.update "_aether.createAPIClone(_aether, #{node.source()})"
   else if node.type is S.VariableDeclaration
     parameters = (param.name for param in (node.parent.parent.params ? []))
-    protectors = ("#{parameter} = _aether.createAPIClone(#{parameter});" for parameter in parameters)
-    argumentsProtector = "for(var __argIndexer = 0; __argIndexer < arguments.length; ++__argIndexer) arguments[__argIndexer] = _aether.createAPIClone(arguments[__argIndexer]);"
+    protectors = ("#{parameter} = _aether.createAPIClone(_aether, #{parameter});" for parameter in parameters)
+    argumentsProtector = "for(var __argIndexer = 0; __argIndexer < arguments.length; ++__argIndexer) arguments[__argIndexer] = _aether.createAPIClone(_aether, arguments[__argIndexer]);"
     node.update "#{node.source()} #{protectors.join ' '} #{argumentsProtector}"
     #console.log "variable declaration #{node.source()} grandparent is", node.parent.parent
 

--- a/test/protect_api_spec.coffee
+++ b/test/protect_api_spec.coffee
@@ -313,12 +313,16 @@ describe "API Protection Test Suite", ->
       mama._aetherAPIMethodsAllowed = true
       expect(method()).toEqual i + 1
       mama._aetherAPIMethodsAllowed = false
-      for prop of mama.__aetherAPIClone when typeof mama[prop] is 'undefined' and not (prop in (mama.apiUserProperties ? []))
+
+      # Get the API clone of the mama object
+      clone = aether.protectAPIValuesToClones[mama.__aetherID]
+
+      for prop of clone when typeof mama[prop] is 'undefined' and not (prop in (mama.apiUserProperties ? []))
         mama.apiUserProperties ?= []
         mama.apiUserProperties.push prop
       for prop in (mama.apiUserProperties ? [])
-        mama[prop] = mama.__aetherAPIClone[prop]
-      delete mama.__aetherAPIClone
+        mama[prop] = clone[prop]
+
       expect(mama.infants).toEqual i + 1
       expect(mama.namesUsed.length).toEqual i + 1
       expect(mama.namesLeft.length).toEqual 2 - i


### PR DESCRIPTION
This PR decouples API clones from their values.
It's passing all tests (Except IO) but there's a few things to be aware of
- Creating an API clone will expose that clone to usercode even if you didn't explicitly expose it yourself.
- Any references shared across multiple Aether instances will **NOT** work.

It might be worthwhile building an API for manipulating the value/clone mappings to allow you to share references among multiple Aether instances, but that's outside the scope of this PR.
