### PR TITLE
Rewrite user method calls so we can yield within

### DIFF
--- a/dev/index.coffee
+++ b/dev/index.coffee
@@ -153,7 +153,7 @@ clearOutput = ->
   $("#aether-flows").empty()
   $("#aether-problems").empty()
 
-lastJSInputAether = new Aether language: 'python'
+lastJSInputAether = new Aether
 lastAetherInput = ""
 watchForCodeChanges = ->
   aetherInput = editors[1].getValue()
@@ -499,5 +499,53 @@ examples = [
     else {
       demoShowOutput(aether);
     }
+    '''
+,
+  name: "User method"
+  code: '''
+    function f(self) {
+        self.hesitate();
+        b(self);
+        (function () {
+            self.stroll();
+        })();
+    }
+    function b(self) {
+        self.hesitate();
+    }
+    f(this);
+    this.charge();
+    '''
+
+  aether: '''
+    var aetherOptions = {
+      executionLimit: 1000,
+      problems: {
+        jshint_W040: {level: "ignore"},
+        aether_MissingThis: {level: "warning"}
+      },
+      functionName: "planStrategy",
+      functionParameters: ["retries"],
+      yieldConditionally: true,
+    };
+    var aether = new Aether(aetherOptions);
+    var thisValue = {
+      charge: function() { this.say("attack!"); return "attack!"; },
+      hesitate: function() { this.say("uhh..."); aether._shouldYield = true; },
+      stroll: function() { this.say("strolling..."); aether._shouldYield = true; },
+      say: console.log
+    };
+    var code = grabDemoCode();
+    aether.transpile(code);
+    var method = aether.createMethod(thisValue);
+    var generator = method();
+    aether.sandboxGenerator(generator);
+    var executeSomeMore = function executeSomeMore() {
+      var result = generator.next();
+      demoShowOutput(aether);
+      if(!result.done)
+        setTimeout(executeSomeMore, 2000);
+    };
+    executeSomeMore();
     '''
 ]

--- a/src/aether.coffee
+++ b/src/aether.coffee
@@ -221,8 +221,8 @@ module.exports = class Aether
 
     postNormalizationTransforms = []
     postNormalizationTransforms.unshift transforms.validateReturns if @options.thisValue?.validateReturn  # TODO: parameter/return validation should be part of Aether, not some half-external function call
-    postNormalizationTransforms.unshift transforms.yieldConditionally if @options.yieldConditionally
-    postNormalizationTransforms.unshift transforms.yieldAutomatically if @options.yieldAutomatically
+    postNormalizationTransforms.unshift transforms.makeYieldConditionally() if @options.yieldConditionally
+    postNormalizationTransforms.unshift transforms.makeYieldAutomatically() if @options.yieldAutomatically
     if @options.includeFlow
       postNormalizationTransforms.unshift transforms.makeInstrumentStatements varNames
     else if @options.includeMetrics or @options.executionLimit

--- a/test/es6_spec.coffee
+++ b/test/es6_spec.coffee
@@ -72,6 +72,29 @@ describe "ES6 Test Suite", ->
         if gen.next().done then break else ++i
       expect(i < 100).toBe true
 
+    it "with user method", ->
+      dude =
+        charge: -> "attack!"
+      code = """
+        function f(self) {
+          self.charge();
+        }
+        f(this);
+        var x = 3;
+        x += 5 * 8;
+        return this.charge();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      # At least four times
+      for i in [0 ... 4]
+        expect(gen.next().done).toEqual false
+      # Should stop eventually
+      while i < 100
+        if gen.next().done then break else ++i
+      expect(i < 100).toBe true
+
   describe "No yielding", ->
     aether = new Aether
     it "should not yield", ->
@@ -136,3 +159,379 @@ describe "ES6 Test Suite", ->
       expect(gen.next().done).toEqual false
       expect(gen.next().done).toEqual false
       expect(gen.next().done).toEqual true
+
+  describe "User method conditional yielding", ->
+    aether = new Aether yieldConditionally: true
+    it "Simple fn decl", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        function f(self) {
+          self.hesitate();
+          self.hesitate();
+          self.slay();
+        }
+        f(this);
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Fn decl after call", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        f(this);
+        function f(self) {
+          self.hesitate();
+          self.hesitate();
+          self.slay();
+        }
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Simple fn expr", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        this.f = function() {
+          this.hesitate();
+          this.hesitate();
+          this.hesitate();
+        };
+        this.f();
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "IIFE", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        (function (self) {
+          for (var i = 0, max = 3; i < max; ++i) {
+            self.hesitate();
+          }
+        })(this);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "IIFE with .call()", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        (function () {
+          for (var i = 0, max = 3; i < max; ++i) {
+            this.hesitate();
+          }
+        }).call(this);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "IIFE without generatorify", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        (function (self) {
+          self.slay();
+        })(this);        
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Nested methods one generatorify", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        (function (self) {
+          function f(self) {
+            self.hesitate();
+          }
+          f(self);
+          self.slay();
+        })(this);        
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Nested methods many generatorify", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        (function (self) {
+          function f(self) {
+            self.hesitate();
+            var f2 = function(self, n) {
+              for (var i = 0; i < n; i++) {
+                self.hesitate();
+              }
+            }
+            f2(self, 2);
+            self.hesitate();
+          }
+          f(self);
+          self.hesitate();
+          self.slay();
+        })(this);        
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+     it "Call user fn decl from another user method", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+         function f(self) {
+            self.hesitate();
+            b(self);
+            (function () {
+                self.hesitate();
+            })();
+        }
+        function b(self) {
+            self.hesitate();
+        }
+        f(this);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+     it "Call user fn expr from another user method", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        this.b = function () {
+            this.hesitate();
+        };
+         function f(self) {
+            var x = self;
+            x.b();
+        }
+        var y = this;
+        f(y);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Complex objects", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        var o1 = {};
+        o1.m = function(self) {
+          self.hesitate();
+        };
+        o1.o2 = {};
+        o1.o2.m = function(self) {
+          self.hesitate();
+        };
+        o1.m(this);
+        o1.o2.m(this);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Functions as parameters", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        function f(m, self) {
+            m(self);
+        }
+        function b(self) {
+          self.hesitate();
+        }
+        f(b, this);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Nested clauses", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        this.b = function (self) {
+            self.hesitate();
+        }
+        function f(self) {
+          self.hesitate();
+          self.b(self);
+        }
+        if (true) {
+          f(this);
+        }
+        for (var i = 0; i < 2; i++) {
+          if (i === 1) {
+            f(this);
+          }
+        }
+        var inc = 0;
+        while (inc < 2) {
+          f(this);
+          inc += 1;
+        }
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    it "Recursive user function", ->
+      dude =
+        slay: -> @enemy = "slain!"
+        hesitate: -> aether._shouldYield = true
+      code = """
+        function f(self, n) {
+          self.hesitate();
+          if (n > 0) {
+            f(self, n - 1);
+          }
+        }
+        f(this, 2);
+        this.slay();
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.enemy).toEqual "slain!"
+
+    # TODO: Method reassignment not supported yet
+    #it "Reassigning methods", ->
+    #  dude =
+    #    slay: -> @enemy = "slain!"
+    #    hesitate: -> aether._shouldYield = true
+    #  code = """
+    #    function f(self) {
+    #      self.hesitate();
+    #    }
+    #    var b = f;
+    #    b(this);
+    #    this.slay();
+    #  """
+    #  aether.transpile code
+    #  f = aether.createFunction()
+    #  gen = f.apply dude
+    #  expect(gen.next().done).toEqual false
+    #  expect(gen.next().done).toEqual true
+    #  expect(dude.enemy).toEqual "slain!"
+
+    # TODO: Calling inner function returned from another function is not supported yet
+    #it "Return user function", ->
+    #  dude =
+    #    slay: -> @enemy = "slain!"
+    #    hesitate: -> aether._shouldYield = true
+    #  code = """
+    #    function f(self) {
+    #      self.hesitate();
+    #    }
+    #    function b() { 
+    #      return f;
+    #    }
+    #    var m = b();
+    #    m(this);
+    #    this.slay();
+    #  """
+    #  aether.transpile code
+    #  f = aether.createFunction()
+    #  gen = f.apply dude
+    #  expect(gen.next().done).toEqual false
+    #  expect(gen.next().done).toEqual true
+    #  expect(dude.enemy).toEqual "slain!"


### PR DESCRIPTION
High level steps:
1. Add yields to inner functions
2. Don't insert an instrumentation yield after user method calls
3. Rewrite calls to generatorified user methods to handle a returned iterator

Knowing when a call is to a user method is the interesting part.  This code makes a mapping between all calls and function expressions once, which is then used to answer 'Is this a user method call?' during the yield transforms.
