### PR TITLE
Return language-specific types from APIs

### DIFF
--- a/src/aether.coffee
+++ b/src/aether.coffee
@@ -234,6 +234,7 @@ module.exports = class Aether
     postNormalizationTransforms.unshift transforms.makeInstrumentCalls() if @options.includeMetrics or @options.includeFlow
     if normalizedSourceMap
       postNormalizationTransforms.unshift transforms.makeFindOriginalNodes originalNodeRanges, @language.wrappedCodePrefix, normalizedSourceMap, normalizedNodeIndex
+    postNormalizationTransforms.unshift transforms.convertToNativeTypes
     postNormalizationTransforms.unshift transforms.protectAPI if @options.protectAPI
     postNormalizationTransforms.unshift transforms.interceptThis
     postNormalizationTransforms.unshift transforms.interceptEval
@@ -295,6 +296,11 @@ module.exports = class Aether
     lines = source.split /\r?\n/
     indent = if lines.length then lines[0].length - lines[0].replace(/^ +/, '').length else 0
     (line.slice indent for line in lines).join '\n'
+
+  convertToNativeType: (obj) ->
+    # Convert obj to current language's equivalent type if necessary
+    # E.g. if language is Python, JavaScript Array is converted to a Python list
+    @language.convertToNativeType(obj)
 
   # Runtime modules
 

--- a/src/languages/language.coffee
+++ b/src/languages/language.coffee
@@ -53,3 +53,8 @@ module.exports = class Language
   # Useful for parsing incomplete code as it is being written without giving up.
   # This should never throw an error and should always return some sort of AST, even if incomplete or empty.
   #parseDammit: (code, aether) ->
+
+  # Convert obj to a language-specific type
+  # E.g. if obj is an Array and language is Python, return a Python list
+  convertToNativeType: (obj) ->
+    obj

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -53,6 +53,9 @@ module.exports = class Python extends Language
       ast = {type: "Program", body:[{"type": "EmptyStatement"}]}
     ast
 
+  convertToNativeType: (obj) ->
+    return parser.pythonRuntime.utils.createList(obj) if not obj?.isPython and _.isArray obj
+    obj
 
 fixLocations = (ast) ->
   wrappedCodeIndent = 4

--- a/src/transforms.coffee
+++ b/src/transforms.coffee
@@ -440,6 +440,13 @@ module.exports.makeInstrumentCalls = makeInstrumentCalls = (varNames) ->
     return unless node.type is S.VariableDeclaration
     node.update "'use strict'; _aether.logCallStart(_aether._userInfo); #{node.source()}"  # TODO: pull in arguments?
 
+module.exports.convertToNativeTypes = (node) ->
+  # Hook all function calls and convert returns to native types if necessary
+  # E.g. return from getEnemies API call is intercepted and converted to a Python list, when language is Python
+  return unless node.type is S.CallExpression
+  return unless getFunctionNestingLevel(node) > 1
+  node.update "_aether.convertToNativeType(#{node.source()})"
+
 module.exports.protectAPI = (node) ->
   return unless node.type in [S.CallExpression, S.ThisExpression, S.VariableDeclaration, S.ReturnStatement]
   level = getFunctionNestingLevel node

--- a/test/python_spec.coffee
+++ b/test/python_spec.coffee
@@ -199,11 +199,23 @@ describe "Python Test suite", ->
       aether.transpile(code)
       expect(aether.run()).toEqual(125)
 
+    it "API returns Python object", ->
+      code ="""
+        items = self.getItems()
+        if items.isPython:
+           return items.count(3)
+        return 'not a Python object'
+      """
+      aether.transpile code
+      selfValue = {getItems: -> [3, 3, 4, 3, 5, 6, 3]}
+      method = aether.createMethod selfValue
+      expect(aether.run(method)).toEqual(4)
+
   describe "Usage", ->
     it "self.doStuff via thisValue param", ->
       history = []
       log = (s) -> history.push s
-      moveDown = () -> history.push 'moveDown'
+      moveDown = -> history.push 'moveDown'
       thisValue = {say: log, moveDown: moveDown}
       aetherOptions = {
         language: 'python'
@@ -233,7 +245,7 @@ describe "Python Test suite", ->
 
     it "self.getItems", ->
       history = []
-      getItems = () -> [{'pos':1}, {'pos':4}, {'pos':3}, {'pos':5}]
+      getItems = -> [{'pos':1}, {'pos':4}, {'pos':3}, {'pos':5}]
       move = (i) -> history.push i
       thisValue = {getItems: getItems, move: move}
       aetherOptions = {


### PR DESCRIPTION
These changes address this problem: when the user code language is Python, a Python list should be returned from Coco APIs like getEnemies(), instead of a vanilla JavaScript Array.

This adds a per-language hook to convert an object returned from an API to the correct type.  The hook is only implemented for Python so far.

This update requires a 'npm update filbert' to pickup required changes in the Python parser.
