### PR TITLE
Create language-specific objects in restoreAPIClone

### DIFF
--- a/dev/index.coffee
+++ b/dev/index.coffee
@@ -218,6 +218,31 @@ examples = [
     demoShowOutput(aether);
     '''
 ,
+  name: "Python protected"
+  code: '''
+    a = [1]
+    b = [2]
+    c = a + b
+    print(c.type)
+    print(c)
+    '''
+
+  aether: '''
+    var thisValue = {say: console.log};
+    var aetherOptions = {
+      executionLimit: 1000,
+      problems: {jshint_W040: {level: "ignore"}},
+      language:'python',
+      protectAPI:true
+    };
+    var aether = new Aether(aetherOptions);
+    var code = grabDemoCode();
+    aether.transpile(code);
+    var method = aether.createMethod(thisValue);
+    aether.run(method);
+    demoShowOutput(aether);
+    '''
+,
   name: "Buggy"
   code: '''
     function distance_squared(from, target) {  // no camelCase

--- a/src/languages/language.coffee
+++ b/src/languages/language.coffee
@@ -58,3 +58,16 @@ module.exports = class Language
   # E.g. if obj is an Array and language is Python, return a Python list
   convertToNativeType: (obj) ->
     obj
+
+  cloneObj: (obj, cloneFn=(o) -> o) ->
+    # Clone obj to a language-specific equivalent object
+    # E.g. if obj is an Array and language is Python, we want a new Python list instead of a JavaScript Array.
+    # Use cloneFn for children and simple types
+    if _.isArray obj
+      result = (cloneFn v for v in obj)
+    else if _.isObject obj
+      result = {}
+      result[k] = cloneFn v for k, v of obj
+    else
+      result = cloneFn obj
+    result

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -57,6 +57,17 @@ module.exports = class Python extends Language
     return parser.pythonRuntime.utils.createList(obj) if not obj?.isPython and _.isArray obj
     obj
 
+  cloneObj: (obj, cloneFn=(o) -> o) ->
+    if _.isArray obj
+      result = new parser.pythonRuntime.objects.list()
+      result.append(cloneFn v) for v in obj
+    else if _.isObject obj
+      result = new parser.pythonRuntime.objects.dict()
+      result[k] = cloneFn v for k, v of obj
+    else
+      result = cloneFn obj
+    result
+
 fixLocations = (ast) ->
   wrappedCodeIndent = 4
   estraverse.traverse ast,

--- a/src/protectAPI.coffee
+++ b/src/protectAPI.coffee
@@ -63,9 +63,10 @@ module.exports.createAPIClone = createAPIClone = (aether, value) ->
 
   if isArr = _.isArray value
     result = ctor value.length
-    # Add array properties assigned by RegExp.exec.
-    result.index = value.index if value.hasOwnProperty "index"
-    result.input = value.input if value.hasOwnProperty "input"
+    if className is regexpClass
+      # Add array properties assigned by RegExp.exec.
+      result.index = value.index if value.hasOwnProperty "index"
+      result.input = value.input if value.hasOwnProperty "input"
   else
     result = {}
 
@@ -129,9 +130,5 @@ module.exports.restoreAPIClone = restoreAPIClone = (aether, value, depth=0) ->
   return value if depth > 1  # hack, but I don't understand right now--when do we stop? can't recurse forever
 
   # We now have a new array/object that may contain some clones, so let's recurse to find them.
-  if isArr = _.isArray value
-    result = (restoreAPIClone aether, v, depth + 1 for v in value)
-  else
-    result = {}
-    result[k] = restoreAPIClone aether, v, depth + 1 for k, v of value
-  result
+  # Use language-specific cloning in case we need a non-JS equivalent
+  aether.language.cloneObj(value, (v) -> restoreAPIClone aether, v, depth + 1)

--- a/test/protect_api_spec.coffee
+++ b/test/protect_api_spec.coffee
@@ -466,3 +466,18 @@ describe "API Protection Test Suite", ->
     expect(result.p1d).toEqual 3
     expect(result.p2d).toEqual 6
     expect(aether.problems.errors).toEqual []
+
+  it 'cloning with non-JS language yields language-specific object', ->
+    code = '''
+      a = [1]
+      a += [2]
+      a *= 3
+      return a
+    '''
+    aether = new Aether protectAPI: true, language:'python'
+    aether.transpile code
+    result = aether.run()
+    expect(result.isPython).toEqual true
+    expect(result.type).toEqual 'list'
+    expect(result).toEqual [1, 2, 1, 2, 1, 2]
+    expect(aether.problems.errors).toEqual []


### PR DESCRIPTION
We need to create code language-specific objects instead of vanilla JavaScript objects in protectAPI.restoreAPIClone()
