### PR TITLE
Simple loops

### DIFF
--- a/dev/index.coffee
+++ b/dev/index.coffee
@@ -218,6 +218,38 @@ examples = [
     demoShowOutput(aether);
     '''
 ,
+  name: "Simple loop yields"
+  code: '''
+    loop() {
+      this.slay();
+      if (this.getKillCount() >= 5) {
+        break;
+      }
+    }
+    '''
+
+  aether: '''
+    var aetherOptions = {
+      yieldConditionally: true,
+      simpleLoops: true,
+    };
+    var aether = new Aether(aetherOptions);
+    var thisValue = {
+      killCount: 0,
+      slay: function() { this.killCount += 1;},
+      getKillCount: function() { return this.killCount; }
+    };
+    var code = grabDemoCode();
+    aether.transpile(code);
+    var method = aether.createMethod(thisValue);
+    var generator = method.apply(thisValue);
+    generator.next();
+    generator.next();
+    generator.next();
+    generator.next();
+    console.log(thisValue.killCount);
+    '''
+,
   name: "Python protected"
   code: '''
     a = [1]

--- a/src/aether.coffee
+++ b/src/aether.coffee
@@ -109,6 +109,7 @@ module.exports = class Aether
   # Transpile it. Even if it can't transpile, it will give syntax errors and warnings and such. Clears any old state.
   transpile: (@raw) ->
     @reset()
+    [@raw, @replacedLoops] = @language.replaceLoops @raw if @options.simpleLoops
     @problems = @lint @raw
     @pure = @purifyCode @raw
     @pure
@@ -225,6 +226,7 @@ module.exports = class Aether
         return ''
 
     postNormalizationTransforms = []
+    postNormalizationTransforms.unshift transforms.makeLoopsYieldConditionally(@replacedLoops, @language.wrappedCodePrefix) if @options.yieldConditionally
     postNormalizationTransforms.unshift transforms.makeYieldConditionally() if @options.yieldConditionally
     postNormalizationTransforms.unshift transforms.makeYieldAutomatically() if @options.yieldAutomatically
     if @options.includeFlow

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -46,6 +46,30 @@ module.exports = class JavaScript extends Language
     traversal.walkAST bAST, removeLocations
     return not _.isEqual(aAST, bAST)
 
+  # Replace instances of 'loop()' with 'while(true)'
+  # Assuming 'loop()' is on a single line, only preceded by whitespace
+  replaceLoops: (rawCode) ->
+    convertedCode = ""
+    replacedLoops = []
+    rangeIndex = 0
+    for line in rawCode.split '\n'
+      lineLength = line.length
+      if line.replace(/^\s+/g, "").indexOf('loop') is 0
+        start = line.indexOf 'loop'
+        end = start + 4
+        end++ while (line[end] != '(' and end < line.length)
+        if end < line.length
+          end++ while (line[end] != ')' and end < line.length)
+          if end < line.length
+            # Replace loop with while, remember line number
+            a = line.split("")
+            a[start..end] = 'while (true)'.split ""
+            line = a.join("")
+            replacedLoops.push rangeIndex + start
+      convertedCode += line + '\n'
+      rangeIndex += lineLength + 1 # + newline
+    [convertedCode, replacedLoops]
+
   # Return an array of problems detected during linting.
   lint: (rawCode, aether) ->
     lintProblems = []

--- a/src/languages/javascript.coffee
+++ b/src/languages/javascript.coffee
@@ -46,28 +46,23 @@ module.exports = class JavaScript extends Language
     traversal.walkAST bAST, removeLocations
     return not _.isEqual(aAST, bAST)
 
-  # Replace instances of 'loop()' with 'while(true)'
+  # Replace instances of 'loop' with 'while (true)'
   # Assuming 'loop()' is on a single line, only preceded by whitespace
   replaceLoops: (rawCode) ->
     convertedCode = ""
     replacedLoops = []
     rangeIndex = 0
     for line in rawCode.split '\n'
-      lineLength = line.length
       if line.replace(/^\s+/g, "").indexOf('loop') is 0
+        # Replace loop with while, remember line number
         start = line.indexOf 'loop'
-        end = start + 4
-        end++ while (line[end] != '(' and end < line.length)
-        if end < line.length
-          end++ while (line[end] != ')' and end < line.length)
-          if end < line.length
-            # Replace loop with while, remember line number
-            a = line.split("")
-            a[start..end] = 'while (true)'.split ""
-            line = a.join("")
-            replacedLoops.push rangeIndex + start
-      convertedCode += line + '\n'
-      rangeIndex += lineLength + 1 # + newline
+        a = line.split("")
+        a[start..start + 3] = 'while (true)'.split ""
+        convertedCode += a.join("")
+        replacedLoops.push rangeIndex + start
+      else
+        convertedCode += line + '\n'
+      rangeIndex += line.length + 1 # + newline
     [convertedCode, replacedLoops]
 
   # Return an array of problems detected during linting.

--- a/src/languages/language.coffee
+++ b/src/languages/language.coffee
@@ -26,6 +26,13 @@ module.exports = class Language
     b = b.replace(/^[ \t]+\/\/.*/g, '').trimRight()
     return a.split('\n').length isnt b.split('\n').length
 
+  # Replace 'loop' statement with equivalent of 'while(true)'
+  # Return updated code, and an array of starting range indexes for replaced loop keywords
+  # E.g. in JavaScript 'loop()' is replaced with 'while(true)'
+  replaceLoops: (rawCode) ->
+    console.warn "Simple loop not implemented for #{@name}"
+    [rawCode, []]
+
   # Return an array of UserCodeProblems detected during linting.
   lint: (rawCode, aether) ->
     []

--- a/src/languages/python.coffee
+++ b/src/languages/python.coffee
@@ -24,6 +24,28 @@ module.exports = class Python extends Language
       return not _.isEqual(aAST, bAST)
     catch error
       return true
+  
+  # Replace 'loop:' with 'while True:'
+  # TODO: support 'loop():' too?
+  replaceLoops: (rawCode, aether) ->
+    convertedCode = ""
+    replacedLoops = []
+    rangeIndex = 0
+    for line in rawCode.split '\n'
+      lineLength = line.length
+      if line.replace(/^\s+/g, "").indexOf('loop') is 0
+        start = line.indexOf 'loop'
+        end = start + 4
+        end++ while (line[end] != ':' and end < line.length)
+        if end < line.length
+          # Replace loop with while, remember line number
+          a = line.split("")
+          a[start..end] = 'while True:'.split ""
+          line = a.join("")
+          replacedLoops.push rangeIndex + start
+      convertedCode += line + '\n'
+      rangeIndex += lineLength + 1 + 4 # + newline + wrapped indent
+    [convertedCode, replacedLoops]
 
   # Wrap the user code in a function. Store @wrappedCodePrefix and @wrappedCodeSuffix.
   wrap: (rawCode, aether) ->

--- a/src/validators/options.coffee
+++ b/src/validators/options.coffee
@@ -57,3 +57,7 @@ module.exports = (options) ->
         type: 'boolean'
         default: false
         description: "Whether to clone/restore values coming in and out of user code to limit them to apiProperties."
+      simpleLoops:
+        type: 'boolean'
+        default: false
+        description: "Whether simple loops will be supported, per language.  E.g. 'loop()' will be transpiled as 'while(true)'."

--- a/test/es6_spec.coffee
+++ b/test/es6_spec.coffee
@@ -537,10 +537,10 @@ describe "JavaScript Test Suite", ->
     #  expect(dude.enemy).toEqual "slain!"
 
   describe "Simple loop", ->
-    it "loop() {", ->
+    it "loop{", ->
       code = """
       var total = 0
-      loop() {
+      loop{
         total += 1
         break;
       }
@@ -550,10 +550,10 @@ describe "JavaScript Test Suite", ->
       aether.transpile(code)
       expect(aether.run()).toEqual(1)
 
-    it "loop () {}", ->
+    it "loop {}", ->
       code = """
       var total = 0
-      loop () { total += 1; if (total >= 12) {break;}}
+      loop { total += 1; if (total >= 12) {break;}}
       return total
       """
       aether = new Aether language: "javascript", simpleLoops: true
@@ -571,7 +571,7 @@ describe "JavaScript Test Suite", ->
           this.slay();
           break;
         }
-        loop() {
+        loop {
           this.slay();
           if (this.getKillCount() >= 5) {
             break;
@@ -606,7 +606,7 @@ describe "JavaScript Test Suite", ->
           this.slay();
           break;
         }
-        loop() {
+        loop {
           this.slay();
           if (this.getKillCount() >= 5) {
             break;
@@ -624,5 +624,3 @@ describe "JavaScript Test Suite", ->
       while (true)
         if gen.next().done then break
       expect(dude.killCount).toEqual 6
-
-

--- a/test/python_spec.coffee
+++ b/test/python_spec.coffee
@@ -371,3 +371,70 @@ describe "Python Test suite", ->
       expect(aether.problems.errors[0].range).toEqual([ { ofs : 4, row : 0, col : 4 }, { ofs : 7, row : 0, col : 7 } ])
       result = aether.run()
       expect(result).toEqual('hi')
+
+  describe "Simple loop", ->
+    it "loop:", ->
+      code = """
+      total = 0
+      loop:
+        total += 1
+        if total is 10: break;
+      return total
+      """
+      aether = new Aether language: "python", simpleLoops: true
+      aether.transpile(code)
+      expect(aether.run()).toEqual(10)
+
+    xit "one line", ->
+      # Blocked by https://github.com/differentmatt/filbert/issues/41
+      code = """
+      total = 0
+      loop: total += 12; break;
+      return total
+      """
+      aether = new Aether language: "python", simpleLoops: true
+      aether.transpile(code)
+      expect(aether.run()).toEqual(12)
+
+    it "loop  :", ->
+      code = """
+      total = 0
+      loop  :
+        total += 23;
+        break;
+      return total
+      """
+      aether = new Aether language: "python", simpleLoops: true
+      aether.transpile(code)
+      expect(aether.run()).toEqual(23)
+      
+    it "Conditional yielding", ->
+      aether = new Aether language: "python", yieldConditionally: true, simpleLoops: true
+      dude =
+        killCount: 0
+        slay: -> @killCount += 1
+        getKillCount: -> return @killCount
+      code = """
+        while True:
+          self.slay();
+          break;
+        loop:
+          self.slay();
+          if self.getKillCount() >= 5:
+            break;
+        while True:
+          self.slay();
+          break;
+      """
+      aether.transpile code
+      f = aether.createFunction()
+      gen = f.apply dude
+      aether._shouldYield = true
+      expect(gen.next().done).toEqual false
+      aether._shouldYield = true
+      expect(gen.next().done).toEqual false
+      aether._shouldYield = true
+      expect(gen.next().done).toEqual false
+      expect(gen.next().done).toEqual true
+      expect(dude.killCount).toEqual 6
+


### PR DESCRIPTION
Adding support for a ‘loop’ keyword that is replaced with a while(true)
equivalent before the linting stage.  For each simple loop, a
conditional yield is added at the end.  Simple loops are processed
per-language.
