### PR TITLE
Added option to skip restoreBuiltins

### DIFF
--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -16,3 +16,4 @@ module.exports = defaults =
   includeMetrics: true
   includeStyle: true
   protectAPI: false
+  restoreBuiltins: true

--- a/src/protectBuiltins.coffee
+++ b/src/protectBuiltins.coffee
@@ -109,7 +109,7 @@ module.exports.wrapWithSandbox = wrapWithSandbox = (self, fn) ->
       result = fn.apply @, arguments
     finally
       self.depth--
-      if self.depth <= 0
+      if self.depth <= 0 && self.options.restoreBuiltins
         # Shouldn't ever be less than 0
         # Should we throw an exception if it is?
         restoreBuiltins()


### PR DESCRIPTION
I added an option to skip `restoreBuiltins` in wrapWithSandbox.  This is a work around for #136 although perhaps temporary.  I'm not sure if anyone needs this besides me.