### PR TITLE
Add initial support for built-in methods with generatorified callbacks

### DIFF
--- a/src/protectAPI.coffee
+++ b/src/protectAPI.coffee
@@ -35,7 +35,7 @@ reFlags = /\w*$/
 
 # Hacky reimplementation of lodash's cloneDeep, minus the parts we don't need, plus limiting clones to apiProperties.
 module.exports.createAPIClone = createAPIClone = (aether, value) ->
-  return value unless _.isObject value
+  return value if not _.isObject(value) or 'next' of value
   className = Object::toString.call value
   return value unless cloneableClasses[className]
   ctor = ctorByClass[className]

--- a/src/transforms.coffee
+++ b/src/transforms.coffee
@@ -383,7 +383,7 @@ module.exports.makeYieldConditionally = makeYieldConditionally = (simpleLoops, w
       node.yields = true
       possiblyGeneratorifyAncestorFunction node unless node.mustBecomeGeneratorFunction
     else if node.mustBecomeGeneratorFunction
-      node.update node.source().replace /^function /, 'function* '
+      node.update "(_tmp = #{node.source().replace(/^function /, "function* ")}, _tmp._isAetherGen = true, _tmp)"
     else if node.type is S.AssignmentExpression and node.right?.type is S.CallExpression
       # Update call to generatorified user function to process yields, and set return result
       userFnMap = getUserFnMap(node, @language) unless userFnMap
@@ -395,6 +395,9 @@ module.exports.makeYieldConditionally = makeYieldConditionally = (simpleLoops, w
         else
           autoYieldStmt = ""
         node.update "var __gen#{node.left.source()} = #{node.right.source()}; while (true) { var __result#{node.left.source()} = __gen#{node.left.source()}.next(); if (__result#{node.left.source()}.done) { #{node.left.source()} = __result#{node.left.source()}.value; break; } var _yieldValue = __result#{node.left.source()}.value; if (this.onAetherYield) { this.onAetherYield(_yieldValue); } yield _yieldValue; #{autoYieldStmt} }"
+      else if node.right.callee.type is S.MemberExpression and node.originalNode.callee?.property?.name in ["forEach", "map"] and node.right.arguments.length
+        arg = node.right.arguments[0].name
+        node.update "if (#{arg} && #{arg}._isAetherGen) { var __gen#{node.left.source()} = #{node.right.source()}; while (true) { var __result#{node.left.source()} = __gen#{node.left.source()}.next(); if (__result#{node.left.source()}.done) { #{node.left.source()} = __result#{node.left.source()}.value; break; } var _yieldValue = __result#{node.left.source()}.value; if (this.onAetherYield) { this.onAetherYield(_yieldValue); } yield _yieldValue;}} else { #{node.source()}; }"
 
 module.exports.makeSimpleLoopsYieldAutomatically = makeSimpleLoopsYieldAutomatically = (replacedLoops, wrappedCodePrefix) ->
   # Add a yield to the end of simple loops, which executes if no other yields do


### PR DESCRIPTION
This is an initial proof of concept for codecombat/codecombat#2874.

This PR, together with codecombat/codecombat#3433 adds support for built-in methods that accept generator functions as callbacks. As this is an early proof of concept, I've only added the `[].forEach` and `[].map` methods, in a pretty hackish way.

Please refer to codecombat/codecombat#xxx for details.

Here are a few things I already know that are missing:

- [ ] "Yield automatically" mode
- [ ] Tests

This is an early proof of concept, so please take a look and see if it is even worth considering to work on.